### PR TITLE
Export Map in the "any" attributes

### DIFF
--- a/epcis-legacy-client/src/main/java/org/oliot/epcis_client/CaptureUtil.java
+++ b/epcis-legacy-client/src/main/java/org/oliot/epcis_client/CaptureUtil.java
@@ -321,6 +321,16 @@ public class CaptureUtil {
 				arr.add(convertToBsonValue(it.next()));
 			}
 			value = arr;
+		} else if (o instanceof Map) {
+			BsonDocument document = new BsonDocument();
+			@SuppressWarnings("unchecked")
+			Map<Object, Object> map = (Map<Object, Object>) o;
+			Iterator<Object> it = map.keySet().iterator();
+			while (it.hasNext()) {
+				String key = it.next().toString();
+				document.put(key, convertToBsonValue(map.get(key)));
+			}
+			value = document;
 		} else {
 			value = new BsonString(o.toString());
 		}

--- a/epcis-legacy/src/main/java/org/oliot/epcis/serde/mongodb/MongoReaderUtil.java
+++ b/epcis-legacy/src/main/java/org/oliot/epcis/serde/mongodb/MongoReaderUtil.java
@@ -96,9 +96,7 @@ public class MongoReaderUtil {
 						elementList.add(parentElement);
 
 					} else if (isBsonDocument) {
-						String documentSuffix = "Document";
-						String parentTagName = anyKey.endsWith(documentSuffix) ? anyKey : anyKey + documentSuffix;
-						Element parentElement = doc.createElement(parentTagName);
+						Element parentElement = doc.createElement(anyKey);
 						if (namespace != null) {
 							parentElement.setAttribute("xmlns:" + namespace, namespaceURI);
 						}

--- a/epcis-legacy/src/main/java/org/oliot/epcis/serde/mongodb/MongoReaderUtil.java
+++ b/epcis-legacy/src/main/java/org/oliot/epcis/serde/mongodb/MongoReaderUtil.java
@@ -98,13 +98,19 @@ public class MongoReaderUtil {
 					} else if (isBsonDocument) {
 						String documentSuffix = "Document";
 						String parentTagName = anyKey.endsWith(documentSuffix) ? anyKey : anyKey + documentSuffix;
-						Element parentElement = createElement(doc, parentTagName, namespace, namespaceURI);
+						Element parentElement = doc.createElement(parentTagName);
+						if (namespace != null) {
+							parentElement.setAttribute("xmlns:" + namespace, namespaceURI);
+						}
 						for(Element child : convertBsonValueToDocumentElements(bsonValue, doc, namespace, namespaceURI)) {
 							parentElement.appendChild(child);
 						}
 						elementList.add(parentElement);
 					} else {
-						Element element = createElement(doc, anyKey, namespace, namespaceURI);
+						Element element = doc.createElement(anyKey);
+						if (namespace != null) {
+							element.setAttribute("xmlns:" + namespace, namespaceURI);
+						}
 						element.setTextContent(value);
 						elementList.add(element);
 					}
@@ -134,26 +140,24 @@ public class MongoReaderUtil {
 		return value;
 	}
 
-	private static Element createElement(Document doc, String tagName, String namespace, String namespaceURI) {
-		Element element = doc.createElement(tagName);
-		if (namespace != null) {
-			element.setAttribute("xmlns:" + namespace, namespaceURI);
-		}
-		return element;
-	}
-
 	private static Element convertBsonValueToArrayElement(BsonValue bsonValue, String anyKey, Document doc, String namespace, String namespaceURI) {
 		String listSuffix = "List";
 		String parentTagName = anyKey.endsWith(listSuffix) ? anyKey : anyKey + listSuffix;
 		String childTagName = anyKey.endsWith(listSuffix)
 				? anyKey.substring(0, anyKey.length() - listSuffix.length()) : anyKey;
 
-		Element parentElement = createElement(doc, parentTagName, namespace, namespaceURI);
+		Element parentElement = doc.createElement(parentTagName);
+		if (namespace != null) {
+			parentElement.setAttribute("xmlns:" + namespace, namespaceURI);
+		}
 		BsonArray arr = bsonValue.asArray();
 		Iterator<BsonValue> it = arr.iterator();
 		while (it.hasNext()) {
 			bsonValue = it.next();
-			Element element = createElement(doc, childTagName, namespace, namespaceURI);
+			Element element = doc.createElement(childTagName);
+			if (namespace != null) {
+				parentElement.setAttribute("xmlns:" + namespace, namespaceURI);
+			}
 			if (bsonValue.isArray()) {
 				element.appendChild(convertBsonValueToArrayElement(bsonValue, anyKey, doc, namespace, namespaceURI));
 			} else if (bsonValue.isDocument()) {


### PR DESCRIPTION
PR to be able to use Map in "any" with Oliot (Legacy).

For example, the following JSON :

```
"namespace:myMap" : {
  "firstProperty": "1",
  "innerMap": {
    "secondProperty": "2"
  },
  "innerArray": [3,4,5]
}
```

produces the following XML :

```
<namespace:myMap xmlns:namespace="http://example.namespace">
  <firstProperty>1</firstProperty>
  <innerMap>
    <secondProperty>2</secondProperty>
  </innerMap>
  <innerArrayList>
    <innerArray>3</innerArray>
    <innerArray>4</innerArray>
    <innerArray>5</innerArray>
  </innerArrayList>
</namespace:myMap>
```

The Bson is converted recursively so that arrays and documents can contain documents/arrays/strings.