### PR TITLE
fix: rename "EPCglobal" to "epcglobal" everywhere

### DIFF
--- a/epcis-server/src/main/java/org/oliot/epcis/model/Document.java
+++ b/epcis-server/src/main/java/org/oliot/epcis/model/Document.java
@@ -18,7 +18,7 @@ import javax.xml.datatype.XMLGregorianCalendar;
 
 /**
  * 
- * EPCglobal document properties for all messages.
+ * epcglobal document properties for all messages.
  * 
  * 
  * <p>

--- a/epcis-server/src/main/resources/schema/epcglobal-epcis-2_0.xsd
+++ b/epcis-server/src/main/resources/schema/epcglobal-epcis-2_0.xsd
@@ -24,7 +24,7 @@
         </xsd:documentation>
     </xsd:annotation>
     <xsd:import namespace="urn:epcglobal:xsd:1"
-                schemaLocation="EPCglobal.xsd"/>
+                schemaLocation="epcglobal.xsd"/>
     <xsd:import namespace="http://www.unece.org/cefact/namespaces/StandardBusinessDocumentHeader"
                 schemaLocation="StandardBusinessDocumentHeader.xsd"/>
     <!-- EPCIS CORE ELEMENTS -->

--- a/epcis-server/src/main/resources/schema/epcglobal-epcis-query-2_0.xsd
+++ b/epcis-server/src/main/resources/schema/epcglobal-epcis-query-2_0.xsd
@@ -34,7 +34,7 @@
     <xsd:import namespace="urn:epcglobal:epcis:xsd:2"
                 schemaLocation="epcglobal-epcis-2_0_detour.xsd"/>
 	<xsd:import namespace="urn:epcglobal:xsd:1"
-                schemaLocation="EPCglobal.xsd"/>
+                schemaLocation="epcglobal.xsd"/>
 
     <xsd:element name="EPCISQueryDocument" type="epcisq:EPCISQueryDocumentType"/>
     <xsd:complexType name="EPCISQueryDocumentType">

--- a/epcis-server/src/main/resources/schema/epcglobal-epcis-query.wsdl
+++ b/epcis-server/src/main/resources/schema/epcglobal-epcis-query.wsdl
@@ -475,13 +475,13 @@ GS1 retains the right to make changes to this document at any time, without noti
   </wsdl:binding>
 
   <!-- EPCISSERVICE -->
-  <wsdl:service name="EPCglobalEPCISService">
-    <wsdl:port binding="impl:EPCISServiceBinding" name="EPCglobalEPCISServicePort">
+  <wsdl:service name="epcglobalEPCISService">
+    <wsdl:port binding="impl:EPCISServiceBinding" name="epcglobalEPCISServicePort">
     <!-- The address shown below is an example; an implementation MAY specify
          any port it wishes
      -->
       <wsdlsoap:address
-         location="http://localhost:6060/axis/services/EPCglobalEPCISService"/>
+         location="http://localhost:6060/axis/services/epcglobalEPCISService"/>
     </wsdl:port>
   </wsdl:service>
 

--- a/epcis-server/src/main/resources/schema/epcglobal.xsd
+++ b/epcis-server/src/main/resources/schema/epcglobal.xsd
@@ -2,14 +2,14 @@
 	<xsd:annotation>
 		<xsd:documentation>
 			<epcglobal:copyright>Copyright (C) 2004 Epcglobal Inc., All Rights Reserved.</epcglobal:copyright>
-			<epcglobal:disclaimer>EPCglobal Inc., its members, officers, directors, employees, or agents shall not be liable for any injury, loss, damages, financial or otherwise, arising from, related to, or caused by the use of this document.  The use of said document shall constitute your express consent to the foregoing exculpation.</epcglobal:disclaimer>
-			<epcglobal:specification>EPCglobal common components Version 1.0</epcglobal:specification>
+			<epcglobal:disclaimer>epcglobal Inc., its members, officers, directors, employees, or agents shall not be liable for any injury, loss, damages, financial or otherwise, arising from, related to, or caused by the use of this document.  The use of said document shall constitute your express consent to the foregoing exculpation.</epcglobal:disclaimer>
+			<epcglobal:specification>epcglobal common components Version 1.0</epcglobal:specification>
 		</xsd:documentation>
 	</xsd:annotation>
 	<xsd:complexType name="Document" abstract="true">
 		<xsd:annotation>
 			<xsd:documentation xml:lang="en">
-         EPCglobal document properties for all messages.
+         epcglobal document properties for all messages.
       </xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="schemaVersion" type="xsd:decimal" use="required">

--- a/epcis-server/src/main/resources/schema/openapi.json
+++ b/epcis-server/src/main/resources/schema/openapi.json
@@ -6237,8 +6237,8 @@
 					"namespace": "urn:epcglobal:epcis-query:xsd:2"
 				},
 				"externalDocs": {
-					"description": "An EPCIS document that must be validated with the [XML Schema](../XSD/EPCglobal-epcis-query-2_0.xsd)\n",
-					"url": "../XSD/EPCglobal-epcis-query-2_0.xsd"
+					"description": "An EPCIS document that must be validated with the [XML Schema](../XSD/epcglobal-epcis-query-2_0.xsd)\n",
+					"url": "../XSD/epcglobal-epcis-query-2_0.xsd"
 				}
 			},
 			"Link": {

--- a/epcis-server/src/main/resources/schema/openapi_remaining.json
+++ b/epcis-server/src/main/resources/schema/openapi_remaining.json
@@ -5956,8 +5956,8 @@
 					"namespace": "urn:epcglobal:epcis-query:xsd:2"
 				},
 				"externalDocs": {
-					"description": "An EPCIS document that must be validated with the [XML Schema](../XSD/EPCglobal-epcis-query-2_0.xsd)\n",
-					"url": "../XSD/EPCglobal-epcis-query-2_0.xsd"
+					"description": "An EPCIS document that must be validated with the [XML Schema](../XSD/epcglobal-epcis-query-2_0.xsd)\n",
+					"url": "../XSD/epcglobal-epcis-query-2_0.xsd"
 				}
 			},
 			"Link": {


### PR DESCRIPTION
There were still a few places where the previous EPCglobal filenames were referenced.