### PR TITLE
Update Docker maven image for JDK 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.9.3-eclipse-temurin-20
+FROM maven:3.9.6-eclipse-temurin-21
 
 WORKDIR /project
 COPY ./epcis-server/ /project/


### PR DESCRIPTION
The current image produces an error because the JDK versions of EPCIS (JDK21) and the Maven image (JDK 20) are incompatible.